### PR TITLE
fix: Ensure comments in .env.example are on separate lines

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,17 +2,24 @@
 REDDIT_CLIENT_ID=""
 REDDIT_CLIENT_SECRET=""
 REDDIT_USER_AGENT=""
-REDDIT_USERNAME="" # Optional, but recommended for some endpoints
-REDDIT_PASSWORD="" # Optional
+# Optional, but recommended for some endpoints
+REDDIT_USERNAME=""
+# Optional
+REDDIT_PASSWORD=""
 
 # Gemini API Credentials
 GEMINI_API_KEY=""
 
 # Scheduler Configuration
-CRAWL_INTERVAL_SECONDS=7200 # Default: 2 hours
-POST_LIMIT_PER_CYCLE=15     # Default: 15 posts per crawl cycle
+# Default: 7200 seconds (2 hours) - How often to fetch new data
+CRAWL_INTERVAL_SECONDS=7200
+# Default: 15 - Max new posts to process each crawl cycle
+POST_LIMIT_PER_CYCLE=15
 
 # Web Server Configuration
-PORT=8080                   # Default: Port for the web server
-GUNICORN_WORKERS=2          # Default: Number of Gunicorn worker processes (relevant when running in Docker)
-# SIMPLE_API_KEY=""         # Optional: Define a simple API key to protect certain future management/data endpoints
+# Default: 8080 - Port the web server will listen on
+PORT=8080
+# Default: 2 - Number of Gunicorn worker processes (relevant when running in Docker)
+GUNICORN_WORKERS=2
+# Optional: Define a simple API key to protect certain future management/data endpoints
+# SIMPLE_API_KEY=""


### PR DESCRIPTION
Trailing comments on variable lines in the .env.example file could lead to issues if copied directly into a .env file, particularly for variables used in shell commands (e.g., PORT in Docker CMD).

This change moves all comments to their own lines to prevent such parsing errors by Gunicorn or other shell-interpreted commands.