### PR TITLE
fix: Centralize load_dotenv call in main.py

### DIFF
--- a/app/gemini_client.py
+++ b/app/gemini_client.py
@@ -1,8 +1,8 @@
 import google.generativeai as genai
 import os
-from dotenv import load_dotenv
+# from dotenv import load_dotenv # Removed, should be loaded in main.py
 
-load_dotenv()
+# load_dotenv() # Removed
 
 def configure_gemini():
     """

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,12 @@
-from flask import Flask, render_template, jsonify
 import os
-from dotenv import load_dotenv
 import threading
-
-# Load environment variables from .env file
+# Load environment variables *before* other application imports that might need them
+from dotenv import load_dotenv
 load_dotenv()
 
-# Import components from your application
+from flask import Flask, render_template, jsonify
+
+# Import components from your application AFTER load_dotenv
 from .analysis import get_analyzed_data, ANALYZED_DATA_STORE, PROCESSED_ITEM_IDS
 from .scheduler import run_scheduler_in_thread, initialize_clients as initialize_scheduler_clients
 

--- a/app/reddit_client.py
+++ b/app/reddit_client.py
@@ -1,8 +1,8 @@
 import praw
 import os
-from dotenv import load_dotenv
+# from dotenv import load_dotenv # Removed, should be loaded in main.py
 
-load_dotenv()
+# load_dotenv() # Removed
 
 def get_reddit_instance():
     """

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -2,7 +2,7 @@ import schedule
 import time
 import threading
 import os
-from dotenv import load_dotenv
+# from dotenv import load_dotenv # Removed, should be loaded in main.py
 
 from .reddit_client import get_reddit_instance
 from .gemini_client import get_gemini_model


### PR DESCRIPTION
I moved the `load_dotenv()` call to the beginning of `app/main.py` before any other application imports. I also removed redundant `load_dotenv()` calls from other modules (`reddit_client`, `gemini_client`, `scheduler`).

This ensures that environment variables from the .env file are loaded consistently once, before any module that might depend on them is imported, which should resolve issues with Gunicorn initialization errors related to module imports and environment variable access.