### PR TITLE
debug: Add explicit early import of google.generativeai in main

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,19 @@ import threading
 from dotenv import load_dotenv
 load_dotenv()
 
+print("dotenv loaded in main.py") # Debug print
+try:
+    import google.generativeai as genai
+    print("Successfully imported google.generativeai in main.py")
+except ImportError as e:
+    print(f"CRITICAL ERROR: Failed to import google.generativeai in main.py: {e}")
+    # Optionally, re-raise or sys.exit to make failure more obvious if this is the root cause
+    raise # This will definitely stop Gunicorn if the import fails here
+except Exception as e:
+    print(f"CRITICAL ERROR: Unexpected error importing google.generativeai in main.py: {e}")
+    raise
+
+
 from flask import Flask, render_template, jsonify
 
 # Import components from your application AFTER load_dotenv


### PR DESCRIPTION
To further diagnose boot failures apparently related to importing the gemini_client (which imports google.generativeai), I've added an explicit import attempt of google.generativeai at the very beginning of app/main.py.

I've included print statements and will raise an exception if this direct import fails. This aims to isolate whether the core issue lies with the google.generativeai package/SDK itself within the Docker environment.