### PR TITLE
debug: Switch to full python:3.11 base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Start with a Python base image
-FROM python:3.11-slim
+# Switch to the full python:3.11 image to test if missing system dependencies
+# in the slim image were causing issues with google-generativeai import.
+FROM python:3.11
 
 # Set the working directory in the container
 WORKDIR /usr/src/app


### PR DESCRIPTION
I changed the Docker base image from python:3.11-slim to python:3.11. This is to test if the persistent ImportError for google.generativeai is due to missing system-level dependencies in the slim image. The full image includes more standard libraries which might be required by the google-generativeai SDK or its dependencies (e.g., grpcio).