### PR TITLE
fix: Remove orphaned load_dotenv call in scheduler.py

### DIFF
--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -8,7 +8,7 @@ from .reddit_client import get_reddit_instance
 from .gemini_client import get_gemini_model
 from .analysis import run_analysis_cycle
 
-load_dotenv()
+# load_dotenv() # Removed - this was causing the NameError
 
 # Global instances for Reddit and Gemini to avoid re-initializing every time
 # This is okay for a single-threaded scheduler. If using multi-threading


### PR DESCRIPTION
Corrects a NameError that occurred because load_dotenv() was called in app/scheduler.py without being imported, after it was centralized to app/main.py.